### PR TITLE
gitConfig: Added 'zip' filter in .git/config

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*.als filter=unzip
+*.als filter=zip

--- a/.gitconfig
+++ b/.gitconfig
@@ -1,5 +1,0 @@
-[filter "unzip"]
-	clean = gzcat -f
-	smudge = gzcat -f
-[diff "gzcat"]
-	textconv = gzcat


### PR DESCRIPTION
 .gitattributes now contains the 'zip'-filter that makes it possible to diff .als-files as .xml
The 'zip'-filter is specified in the .git/config-file.